### PR TITLE
gcc-10 build fix

### DIFF
--- a/portable_concurrency/bits/shared_state.h
+++ b/portable_concurrency/bits/shared_state.h
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <exception>
+#include <stdexcept>
 #include <type_traits>
 
 #include "either.h"


### PR DESCRIPTION
For [std::logic_error](https://en.cppreference.com/w/cpp/error/logic_error).