### PR TITLE
Add make_promise, deprecate promise::get_future

### DIFF
--- a/portable_concurrency/bits/make_future.h
+++ b/portable_concurrency/bits/make_future.h
@@ -24,9 +24,9 @@ using decay_for_future_t = typename decay_for_future<T>::type;
 
 template <typename T>
 future<detail::decay_for_future_t<T>> make_ready_future(T&& value) {
-  promise<detail::decay_for_future_t<T>> promise;
-  promise.set_value(std::forward<T>(value));
-  return promise.get_future();
+  auto promise_and_future = make_promise<detail::decay_for_future_t<T>>();
+  promise_and_future.first.set_value(std::forward<T>(value));
+  return std::move(promise_and_future.second);
 }
 
 future<void> make_ready_future();

--- a/portable_concurrency/bits/portable_concurrency.cpp
+++ b/portable_concurrency/bits/portable_concurrency.cpp
@@ -146,9 +146,9 @@ typename shared_future<void>::get_result_type shared_future<void>::get() const {
 }
 
 future<void> make_ready_future() {
-  promise<void> promise;
-  promise.set_value();
-  return promise.get_future();
+  auto promise_and_future = make_promise<void>();
+  promise_and_future.first.set_value();
+  return std::move(promise_and_future.second);
 }
 
 future<std::tuple<>> when_all() { return make_ready_future(std::tuple<>{}); }

--- a/portable_concurrency/bits/promise.h
+++ b/portable_concurrency/bits/promise.h
@@ -143,7 +143,7 @@ public:
       state->emplace(std::move(val));
   }
 
-  future<T> get_future() { return common_.get_future(); }
+  [[deprecated("Use pc::make_promise instead")]] future<T> get_future() { return common_.get_future(); }
   void set_exception(std::exception_ptr error) { common_.set_exception(error); }
 
   /**
@@ -191,7 +191,7 @@ public:
       state->emplace(val);
   }
 
-  future<T&> get_future() { return common_.get_future(); }
+  [[deprecated("Use pc::make_promise instead")]] future<T&> get_future() { return common_.get_future(); }
   void set_exception(std::exception_ptr error) { common_.set_exception(error); }
 
   bool is_awaiten() const { return common_.is_awaiten(); }
@@ -233,7 +233,7 @@ public:
       state->emplace();
   }
 
-  future<void> get_future() { return common_.get_future(); }
+  [[deprecated("Use pc::make_promise instead")]] future<void> get_future() { return common_.get_future(); }
   void set_exception(std::exception_ptr error) { common_.set_exception(error); }
 
   bool is_awaiten() const { return common_.is_awaiten(); }
@@ -249,6 +249,14 @@ public:
 private:
   detail::promise_common<void> common_;
 };
+
+template <typename T>
+PC_NODISCARD std::pair<promise<T>, future<T>> make_promise()
+{
+  auto state = std::make_shared<detail::shared_state<T>>();
+  auto state_weak = std::weak_ptr<detail::shared_state<T>>(state);
+  return {promise<T>(std::move(state_weak)), future<T>(std::move(state))};
+}
 
 } // namespace cxx14_v1
 } // namespace portable_concurrency

--- a/test/promise.cpp
+++ b/test/promise.cpp
@@ -1,6 +1,7 @@
 #include <future>
 #include <memory>
 #include <string>
+#include <tuple>
 
 #include <gtest/gtest.h>
 
@@ -194,6 +195,16 @@ TYPED_TEST(PromiseTest, moved_from_throws_no_state_on_set_value) {
   pc::promise<TypeParam> promise;
   pc::promise<TypeParam> another_promise{std::move(promise)};
   EXPECT_FUTURE_ERROR(set_promise_value(promise), std::future_errc::no_state);
+}
+
+TYPED_TEST(PromiseTest, make_promise_creates_valid_promise_and_future) {
+  pc::promise<TypeParam> promise;
+  {
+    auto promise_and_future = pc::make_promise<TypeParam>();
+    promise = std::move(promise_and_future.first);
+    EXPECT_TRUE(promise.is_awaiten());
+  }
+  EXPECT_FALSE(promise.is_awaiten());
 }
 
 TEST(Promise, is_awaiten_returns_true_before_get_fututre_call) {

--- a/test/promise.cpp
+++ b/test/promise.cpp
@@ -207,7 +207,7 @@ TYPED_TEST(PromiseTest, make_promise_creates_valid_promise_and_future) {
   EXPECT_FALSE(promise.is_awaiten());
 }
 
-TEST(Promise, is_awaiten_returns_true_before_get_fututre_call) {
+TEST(Promise, is_awaiten_returns_true_before_get_future_call) {
   pc::promise<void> p;
   EXPECT_TRUE(p.is_awaiten());
 }


### PR DESCRIPTION
Current implementation of get_future can't be called concurrently with set_value/set_exception (std::promise has no such problem).
It can be fixed without changing API by storing both shared_ptr<shared_state> and weak_ptr<shared_state> in promise, but it'll increase promise size. Author instead suggested to deprecate get_future and add free function for creating both promise and it's future.