### PR TITLE
Fix unique_function comparation to nullptr

### DIFF
--- a/portable_concurrency/bits/unique_function.h
+++ b/portable_concurrency/bits/unique_function.h
@@ -92,7 +92,7 @@ public:
   /**
    * Also checks if this object holds a function
    */
-  bool operator==(std::nullptr_t) const noexcept { return static_cast<bool>(func_); }
+  bool operator==(std::nullptr_t) const noexcept { return !static_cast<bool>(func_); }
 
 private:
   template <typename F>


### PR DESCRIPTION
unique_function is equal to nullptr if it **does not** hold a function