### PR TITLE
msvc 14.31.31103 compilation issue fix

### DIFF
--- a/portable_concurrency/bits/timed_waiter.h
+++ b/portable_concurrency/bits/timed_waiter.h
@@ -41,7 +41,10 @@ public:
   template <typename T>
   explicit timed_waiter(future<T>& fut) : waiter_{std::make_shared<waiter>()} {
     fut.notify([waiter = waiter_] {
-      std::lock_guard<std::mutex>{waiter->mutex}, waiter->notified = true;
+      {
+        std::lock_guard<std::mutex> lock{waiter->mutex};
+        waiter->notified = true;
+      }
       waiter->cv.notify_all();
     });
   }
@@ -51,7 +54,10 @@ public:
   template <typename T>
   explicit timed_waiter(shared_future<T>& fut) : waiter_{std::make_shared<waiter>()} {
     fut.notify([waiter = waiter_] {
-      std::lock_guard<std::mutex>{waiter->mutex}, waiter->notified = true;
+      {
+        std::lock_guard<std::mutex> lock{waiter->mutex};
+        waiter->notified = true;
+      }
       waiter->cv.notify_all();
     });
   }


### PR DESCRIPTION
Hello!
We have a compilation issue.
On MSVC 14.31.31103 we get a warning:
portable_concurrency\bits\timed_waiter.h(44,34): warning C4834: discarding return value of function with 'nodiscard' attribute

We solved this issue like in this pull request and suggest merge it into your project