### PR TITLE
Change behavior of [.stop()] and [.wait()] on [pc::static_thread_pool]

### DIFF
--- a/portable_concurrency/bits/closable_queue.hpp
+++ b/portable_concurrency/bits/closable_queue.hpp
@@ -9,7 +9,7 @@ namespace detail {
 template <typename T> bool closable_queue<T>::pop(T &dest) {
   std::unique_lock<std::mutex> lock(mutex_);
   cv_.wait(lock, [this]() { return closed_ || !queue_.empty(); });
-  if (closed_)
+  if (closed_ && queue_.empty())
     return false;
   std::swap(dest, queue_.front());
   queue_.pop();

--- a/portable_concurrency/bits/thread_pool.h
+++ b/portable_concurrency/bits/thread_pool.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <thread>
 #include <type_traits>
@@ -63,6 +64,7 @@ private:
   unsigned attached_threads_ = 0;
   std::mutex mutex_;
   std::condition_variable cv_;
+  std::atomic<bool> stopped_{false};
 };
 
 } // namespace cxx14_v1

--- a/test/thread_pool.cpp
+++ b/test/thread_pool.cpp
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
 
+#include <portable_concurrency/latch>
 #include <portable_concurrency/thread_pool>
+
+#include <atomic>
 
 namespace {
 
@@ -20,6 +23,58 @@ TEST(ThreadPool, should_execute_function_in_another_thread) {
   std::unique_lock<std::mutex> lock{mtx};
   cv.wait(lock, [&] { return tid != std::thread::id{}; });
   EXPECT_NE(tid, std::this_thread::get_id());
+}
+
+TEST(ThreadPool, processes_all_queued_tasks_when_waited_on) {
+  static constexpr size_t task_count = 1;
+
+  pc::static_thread_pool pool{1};
+
+  std::atomic<size_t> processed_tasks_count{0};
+  pc::latch latch{2};
+
+  post(pool.executor(), [&latch] {
+    latch.count_down_and_wait();
+  });
+
+  for (size_t i = 0; i < task_count; ++i) {
+    post(pool.executor(), [&processed_tasks_count] {
+      ++processed_tasks_count;
+    });
+  }
+
+  latch.count_down_and_wait();
+  pool.wait();
+
+  EXPECT_EQ(processed_tasks_count.load(), task_count);
+}
+
+TEST(ThreadPool, abandons_unprocessed_tasks_when_stopped) {
+  static constexpr size_t task_count = 1;
+
+  pc::static_thread_pool pool{1};
+
+  std::atomic<size_t> processed_tasks_count{0};
+  pc::latch latch_before_stop{2};
+  pc::latch latch_after_stop{2};
+
+  post(pool.executor(), [&latch_before_stop, &latch_after_stop] {
+    latch_before_stop.count_down_and_wait();
+    latch_after_stop.count_down_and_wait();
+  });
+
+  for (size_t i = 0; i < task_count; ++i) {
+    post(pool.executor(), [&processed_tasks_count] {
+      ++processed_tasks_count;
+    });
+  }
+
+  latch_before_stop.count_down_and_wait();
+  pool.stop();
+  latch_after_stop.count_down_and_wait();
+  pool.wait();
+
+  EXPECT_EQ(processed_tasks_count.load(), 0);
 }
 
 } // namespace


### PR DESCRIPTION
[pc::closable_queue<T>::pop()] should only return `false` when the queue is closed (i.e. it will never have more elements) and, crucially, when it is empty. Otherwise the library's thread pool can lose tasks during shutdown.

I've also added a test that demonstrates the problem. Just revert the edit to `portable_concurrency/bits/closable_queue.hpp` and run the tests.

I understand that sometimes it is desirable to shutdown a thread pool ASAP and drop all unprocessed tasks in the queue. I think there should be a clear separation between these two scenarios in the API. Maybe we could add something like a `static_thread_pool::abort()` method that sets an atomic flag (`finished`?). The flag is checked at each iteration in `process_queue()`, and setting it makes the threads in thread pool finish after processing a task without even looking at the queue.